### PR TITLE
feat: implement backend pagination for article list

### DIFF
--- a/src/controllers/news.controller.js
+++ b/src/controllers/news.controller.js
@@ -9,13 +9,28 @@ const newsController = {};
 newsController.getAllNews = async (req, res, next) => {
   try {
     const { keyword } = req.query;
+    const page = Number(req.query.page) || 1;
+    const limit = Number(req.query.limit) || 12;
+    const skip = (page - 1) * limit;
 
-    //검색어 없으면 전체 조회
+
+    //검색어 없으면 전체 조회 + 페이지네이션
     if (!keyword) {
-      const news = await News.find({});
+      const total = await News.countDocuments({});
+      const news = await News.find({})
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit);
+
       return res.status(200).json({
         success: true,
         data: news,
+        pagination: {
+          page,
+          limit,
+          total,
+          totalPages: Math.ceil(total / limit),
+        },
       });
     }
 
@@ -50,9 +65,18 @@ newsController.getAllNews = async (req, res, next) => {
       throw new ApiError("검색 결과가 없습니다.", 404, true);
     }
 
-    res.status(200).json({
+    const total = result.length;
+    const paginatedResult = result.slice(skip, skip + limit);
+
+    return res.status(200).json({
       success: true,
-      data: result,
+      data: paginatedResult,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
     });
   } catch (err) {
     next(err);


### PR DESCRIPTION
## 📌 작업 개요 (Overview)

기사 목록 조회 API에 페이지네이션 기능을 추가했습니다.  
프론트에서 page, limit 값을 전달하면 해당 페이지에 맞는 기사 목록과 
pagination 정보를 반환하도록 수정했습니다.


## ✅ 작업 내용 (Work Done)

- 뉴스 전체 조회 API에 page, limit 쿼리 적용
- 전체 조회 시 pagination 정보(page, limit, total, totalPages) 반환
- 검색 결과 조회 시에도 pagination 정보 반환
- 프론트엔드에서 백엔드 pagination 응답을 사용할 수 있도록 구조 정리

##  reviewers에게

- 기사 목록 조회 및 검색 시 pagination 응답 구조가 적절한지 확인 부탁드립니다.
- 추가로 응답 필드명이나 구조를 통일할 필요가 있으면 말씀 부탁드립니다.
