### PR TITLE
[feat] #50 User Schema에 소셜 로그인 유저 구분용 컬럼 추가

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -135,6 +135,7 @@ authController.googleSignin = async (req, res, next) => {
         email,
         password: tempPassword,
         level: "A2", // 기본값
+        provider: "google",
       });
     }
 

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -28,6 +28,11 @@ const userSchema = Schema(
       type: Boolean,
       default: false,
     },
+    provider: {
+      type: String,
+      enum: ["local", "google"],
+      default: "local",
+    }
   },
   { timestamps: true },
 );


### PR DESCRIPTION
## 📌 작업 개요 (Overview)
User Schema에 소셜 로그인 유저 구분용 컬럼 추가

(Closes #50)


## ✅ 작업 내용 (Work Done)

- [x] User Schema에 필드 추가
- [x] 구글 로그인 로직에 반영

##  reviewers에게
- boolean 타입의 컬럼을 추가하려다, 확장성을 고려해 String enum 타입의 컬럼을 추가했습니다.
